### PR TITLE
Fix bug causing ClassCastException when casting Integer,Short,... to Long object type

### DIFF
--- a/tedisson-spring-boot-starter/src/main/java/com/tosan/client/redis/impl/localCacheManager/caffeine/CaffeineCacheManager.java
+++ b/tedisson-spring-boot-starter/src/main/java/com/tosan/client/redis/impl/localCacheManager/caffeine/CaffeineCacheManager.java
@@ -9,6 +9,7 @@ import com.tosan.client.redis.api.SpringCacheConfig;
 import com.tosan.client.redis.api.listener.CacheListener;
 import com.tosan.client.redis.api.listener.CaffeineCacheListener;
 import com.tosan.client.redis.enumuration.LocalCacheProvider;
+import com.tosan.client.redis.exception.TedissonRuntimeException;
 import com.tosan.client.redis.impl.localCacheManager.LocalCacheManagerBase;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
@@ -155,7 +156,11 @@ public class CaffeineCacheManager extends LocalCacheManagerBase implements Local
             newCaffeineElement.setValue(1L);
             return newCaffeineElement;
         }
-        element.setValue((long) element.getValue() + 1);
+        Object value = element.getValue();
+        if (!(value instanceof Number)) {
+            throw new TedissonRuntimeException("Value must be numeric");
+        }
+        element.setValue(((Number) value).longValue() + 1);
         return element;
     }
 

--- a/tedisson-spring-boot-starter/src/test/java/com/tosan/client/redis/api/integration/LocalCacheManagerITest.java
+++ b/tedisson-spring-boot-starter/src/test/java/com/tosan/client/redis/api/integration/LocalCacheManagerITest.java
@@ -12,7 +12,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-
 class LocalCacheManagerITest extends BaseITest {
 
     public static final String CACHE_WITH_SIZE = "CACHE_WITH_SIZE";
@@ -33,7 +32,6 @@ class LocalCacheManagerITest extends BaseITest {
         Assertions.assertTrue(localCacheManager.isCacheExist(TEST_WITH_EXPIRY_TTL));
         Assertions.assertTrue(localCacheManager.isCacheExist(TEST_WITH_EXPIRY_TTL_TTI));
     }
-
 
     @Test
     void testClearCache() {
@@ -303,6 +301,36 @@ class LocalCacheManagerITest extends BaseITest {
         localCacheManager.expireAtomicItem(cacheName, "atomicKey", 2L, TimeUnit.SECONDS);
         Thread.sleep(3000);
         Assertions.assertEquals(1, localCacheManager.incrementAndGetAtomicItem(cacheName, "atomicKey"));
+    }
+
+    @Test
+    void testIncrementAtomicIntegerValueItem() {
+        String cacheName = "testIncrementAtomicIntegerValueItem";
+        String key = "atomicKey";
+        localCacheManager.createCache(cacheName);
+        Integer item = Integer.valueOf(1);
+        localCacheManager.addItemToCache(cacheName, key, item);
+        Assertions.assertEquals(2, localCacheManager.incrementAndGetAtomicItem(cacheName, key));
+    }
+
+    @Test
+    void testIncrementAtomicLongValueItem() {
+        String cacheName = "testIncrementAtomicLongValueItem";
+        String key = "atomicKey";
+        localCacheManager.createCache(cacheName);
+        Long item = Long.valueOf(1);
+        localCacheManager.addItemToCache(cacheName, key, item);
+        Assertions.assertEquals(2, localCacheManager.incrementAndGetAtomicItem(cacheName, key));
+    }
+
+    @Test
+    void testIncrementAtomicShortValueItem() {
+        String cacheName = "testIncrementAtomicShortValueItem";
+        String key = "atomicKey";
+        localCacheManager.createCache(cacheName);
+        Short item = Short.valueOf((short) 1);
+        localCacheManager.addItemToCache(cacheName, key, item);
+        Assertions.assertEquals(2, localCacheManager.incrementAndGetAtomicItem(cacheName, key));
     }
 
     @Test


### PR DESCRIPTION
If we set a numeric type other than Long after calling `incrementAndGetAtomicItem`, we get a `ClassCastException`. This merge request fixes the issue.